### PR TITLE
convert number strings to int and zero-pad in text string

### DIFF
--- a/Sample Project/BEMAnalogClock/ViewController.m
+++ b/Sample Project/BEMAnalogClock/ViewController.m
@@ -74,7 +74,10 @@
 
 - (void)currentTimeOnClock:(BEMAnalogClockView *)clock Hours:(NSString *)hours Minutes:(NSString *)minutes Seconds:(NSString *)seconds {
     if (clock.tag == 1) {
-        self.myLabel.text = [NSString stringWithFormat:@"%@:%@:%@", hours, minutes, seconds];
+        int hoursInt = [hours intValue];
+        int minutesInt = [minutes intValue];
+        int secondsInt = [seconds intValue];
+        self.myLabel.text = [NSString stringWithFormat:@"%02d:%02d:%02d", hoursInt, minutesInt, secondsInt];
      }
 }
 


### PR DESCRIPTION
The digital clock treats the time components as strings so single digit values aren't zero-padded.
