### PR TITLE
Two fixes and one feature

### DIFF
--- a/Classes/BEMAnalogClockView.h
+++ b/Classes/BEMAnalogClockView.h
@@ -55,6 +55,9 @@
 /// If set to YES, the digits (1-12) will be displayed on the face of the clock. Default value is NO.
 @property (nonatomic) BOOL enableDigit;
 
+/// If set to YES, a circular hub will be drawn. Default value is NO;
+@property (nonatomic) BOOL enableHub;
+
 /// If set to YES, the clock will be updated in real time (the second hand will move every second, the minute hand every minute...). Default value is NO;
 @property (nonatomic) BOOL realTime;
 
@@ -151,6 +154,17 @@
 /// The length of the offside part of the clock's second hand. Default value is 20.
 @property (nonatomic) CGFloat secondHandOffsideLength;
 
+
+//----- HUB CUSTOMIZATION -----//
+
+/// The color of the hub. Default value is whiteColor.
+@property (strong, nonatomic) UIColor *hubColor;
+
+/// The alpha of the clock's hub. Default value is 1.0.
+@property (nonatomic) CGFloat hubAlpha;
+
+/// The width of the clock's hub. Default value is 3.0.
+@property (nonatomic) CGFloat hubRadius;
 
 //------------------------------------------------------------------------------------//
 //----- METHODS ----------------------------------------------------------------------//

--- a/Classes/BEMAnalogClockView.m
+++ b/Classes/BEMAnalogClockView.m
@@ -376,7 +376,7 @@
     } else {
         if (self.hours >= 24) {
             self.hours = 00;
-        } else if (self.hours <= 0) {
+        } else if (self.hours < 0) {
             self.hours = 23;
         }
     }

--- a/Classes/BEMAnalogClockView.m
+++ b/Classes/BEMAnalogClockView.m
@@ -430,11 +430,13 @@
     CGContextStrokePath(ctx);
 
     // HUB
-    CGContextSetFillColorWithColor(ctx, self.hubColor.CGColor);
-    CGContextSetAlpha(ctx, self.hubAlpha);
-    CGPoint center = CGPointMake(self.frame.size.width / 2.0f, self.frame.size.height / 2.0f);
-    CGContextAddArc(ctx, center.x, center.y, self.hubRadius, 0, 2 * M_PI, 0);
-    CGContextFillPath(ctx);
+    if (self.enableHub == YES) {
+        CGContextSetFillColorWithColor(ctx, self.hubColor.CGColor);
+        CGContextSetAlpha(ctx, self.hubAlpha);
+        CGPoint center = CGPointMake(self.frame.size.width / 2.0f, self.frame.size.height / 2.0f);
+        CGContextAddArc(ctx, center.x, center.y, self.hubRadius, 0, 2 * M_PI, 0);
+        CGContextFillPath(ctx);
+    }
 
     // CLOCK'S GRADUATION
     if (self.enableGraduations == YES) {

--- a/Classes/BEMAnalogClockView.m
+++ b/Classes/BEMAnalogClockView.m
@@ -396,13 +396,15 @@
     NSDate *time = [dateFormatter dateFromString:stringTime];
     
     NSCalendar *calendar = [NSCalendar currentCalendar];
-    NSDateComponents *components = [calendar components:(NSHourCalendarUnit |NSMinuteCalendarUnit) fromDate: time];
+    NSDateComponents *components = [calendar components:(NSHourCalendarUnit |NSMinuteCalendarUnit |NSSecondCalendarUnit) fromDate: time];
     
     NSInteger hours = [components hour];
     NSInteger minutes = [components minute];
+    NSInteger seconds = [components second];
     
     self.hours = hours;
     self.minutes = minutes;
+    self.seconds = seconds;
 }
 
 #pragma mark - Drawings

--- a/Classes/BEMAnalogClockView.m
+++ b/Classes/BEMAnalogClockView.m
@@ -85,6 +85,7 @@
     _enableShadows = YES;
     _enableGraduations = YES;
     _enableDigit = NO;
+    _enableHub = NO;
     _realTime = NO;
     _currentTime = NO;
     _setTimeViaTouch = NO;
@@ -113,6 +114,10 @@
     _secondHandWidth = 1;
     _secondHandLength = 60;
     _secondHandOffsideLength = 20;
+
+    _hubColor = [UIColor whiteColor];
+    _hubAlpha = 1.0;
+    _hubRadius = 3.0;
 
     _digitColor = [UIColor whiteColor];
     _digitFont  = [UIFont fontWithName:@"HelveticaNeue-Thin" size:17];
@@ -423,7 +428,14 @@
     CGContextSetAlpha(ctx, self.borderAlpha);
     CGContextSetLineWidth(ctx,self.borderWidth);
     CGContextStrokePath(ctx);
-    
+
+    // HUB
+    CGContextSetFillColorWithColor(ctx, self.hubColor.CGColor);
+    CGContextSetAlpha(ctx, self.hubAlpha);
+    CGPoint center = CGPointMake(self.frame.size.width / 2.0f, self.frame.size.height / 2.0f);
+    CGContextAddArc(ctx, center.x, center.y, self.hubRadius, 0, 2 * M_PI, 0);
+    CGContextFillPath(ctx);
+
     // CLOCK'S GRADUATION
     if (self.enableGraduations == YES) {
         for (int i = 0; i<60; i++) {


### PR DESCRIPTION
I have 3 suggested changes:
Two are fixes, one is a feature:

1. Fix one: (Added seconds to -(void)getTimeFromString)
If time is set with the `-(void)getTimeFromString method`, seconds are ignored and the second hand is not set. My code should change this.

2. Feature: (Added Hub)
I added a customizable hub to the clock, as can be seen in the clocks of the Apple Clock App of the iPhone.

3. Fix two: (Corrected for 00 hours military time)
When military time was moving through 00 hours, `-(void)timeFormatVerification` method turned it back to 23. That is wrong, as there actually is a 00 hour in military time.

BTW, thank you for the clock, I like it very much!

Mathias