### PR TITLE
Allow the clock hands to safely redraw

### DIFF
--- a/BEMAnalogClock.podspec.json
+++ b/BEMAnalogClock.podspec.json
@@ -1,0 +1,26 @@
+{
+  "screenshots": "http://s18.postimg.org/hsff40p5l/BEMAnalog_Clock_Main.png",
+  "source": {
+    "git": "https://github.com/Boris-Em/BEMAnalogClock.git",
+    "tag": "v1.4"
+  },
+  "platforms": {
+    "ios": "6.0"
+  },
+  "source_files": [
+    "Classes",
+    "Classes/*.{h,m}"
+  ],
+  "license": {
+    "file": "LICENSE",
+    "type": "MIT"
+  },
+  "homepage": "https://github.com/Boris-Em/BEMAnalogClock",
+  "name": "BEMAnalogClock",
+  "authors": {
+    "Boris Emorine": "boris.emorine@gmail.com"
+  },
+  "requires_arc": true,
+  "version": "1.4",
+  "summary": "iOS library to create elegant, interactive clocks."
+}

--- a/Classes/BEMAnalogClockView.m
+++ b/Classes/BEMAnalogClockView.m
@@ -146,7 +146,7 @@
         
         [self timeFormatVerification];
         
-        self.hourHand = [[KSMHand alloc] initWithFrame:CGRectMake(0, 0, self.frame.size.width, self.frame.size.height)];
+        self.hourHand = [[KSMHand alloc] initWithFrame:self.bounds];
         self.hourHand.degree = [self degreesFromHour:self.hours andMinutes:self.minutes];
         self.hourHand.color = self.hourHandColor;
         self.hourHand.alpha = self.hourHandAlpha;
@@ -155,7 +155,7 @@
         self.hourHand.offsetLength = self.hourHandOffsideLength;
         [self addSubview:self.hourHand];
         
-        self.minuteHand = [[KSMHand alloc] initWithFrame:CGRectMake(0, 0, self.frame.size.width, self.frame.size.height)];
+        self.minuteHand = [[KSMHand alloc] initWithFrame:self.bounds];
         self.minuteHand.degree = [self degreesFromMinutes:self.minutes];
         self.minuteHand.color = self.minuteHandColor;
         self.minuteHand.alpha = self.minuteHandAlpha;
@@ -164,7 +164,7 @@
         self.minuteHand.offsetLength = self.minuteHandOffsideLength;
         [self addSubview:self.minuteHand];
         
-        self.secondHand = [[KSMHand alloc] initWithFrame:CGRectMake(0, 0, self.frame.size.width, self.frame.size.height)];
+        self.secondHand = [[KSMHand alloc] initWithFrame:self.bounds];
         self.secondHand.degree = [self degreesFromMinutes:self.seconds];
         self.secondHand.color = self.secondHandColor;
         self.secondHand.alpha = self.secondHandAlpha;
@@ -220,9 +220,9 @@
         } else {
             [self timeFormatVerification];
             
-            [KSMHand rotateHand:self.secondHand rotationDegree:[self degreesFromMinutes:self.seconds]];
+            [self.secondHand setDegree:[self degreesFromMinutes:self.seconds] animated:YES];
             if ([self.delegate respondsToSelector:@selector(currentTimeOnClock:Hours:Minutes:Seconds:)]) {
-            [self.delegate currentTimeOnClock:self Hours:[NSString stringWithFormat:@"%li", (long)self.hours] Minutes:[NSString stringWithFormat:@"%li", (long)self.minutes] Seconds:[NSString stringWithFormat:@"%li", (long)self.seconds]];
+                [self.delegate currentTimeOnClock:self Hours:[NSString stringWithFormat:@"%li", (long)self.hours] Minutes:[NSString stringWithFormat:@"%li", (long)self.minutes] Seconds:[NSString stringWithFormat:@"%li", (long)self.seconds]];
             }
         }
     }
@@ -245,18 +245,13 @@
     
     [self timeFormatVerification];
     
-     if (animated == YES) {
-         skipOneCycle = YES;
-         [KSMHand rotateHand:self.minuteHand rotationDegree:[self degreesFromMinutes:self.minutes]];
-         [KSMHand rotateHand:self.hourHand rotationDegree:[self degreesFromHour:self.hours andMinutes:self.minutes]];
-         [KSMHand rotateHand:self.secondHand rotationDegree:[self degreesFromMinutes:self.seconds]];
-     } else {
-         self.minuteHand.transform = CGAffineTransformMakeRotation(([self degreesFromMinutes:self.minutes])*(M_PI/180));
-         self.hourHand.transform = CGAffineTransformMakeRotation(([self degreesFromHour:self.hours andMinutes:self.minutes])*(M_PI/180));
-         self.secondHand.transform = CGAffineTransformMakeRotation(([self degreesFromMinutes:self.seconds])*(M_PI/180));
-     }
+    skipOneCycle = animated;
+    [self.minuteHand setDegree:[self degreesFromMinutes:self.minutes] animated:animated];
+    [self.hourHand   setDegree:[self degreesFromHour:self.hours andMinutes:self.minutes] animated:animated];
+    [self.secondHand setDegree:[self degreesFromMinutes:self.seconds] animated:animated];
+
     if ([self.delegate respondsToSelector:@selector(currentTimeOnClock:Hours:Minutes:Seconds:)]) {
-     [self.delegate currentTimeOnClock:self Hours:[NSString stringWithFormat:@"%li", (long)self.hours] Minutes:[NSString stringWithFormat:@"%li", (long)self.minutes] Seconds:[NSString stringWithFormat:@"%li", (long)self.seconds]];
+        [self.delegate currentTimeOnClock:self Hours:[NSString stringWithFormat:@"%li", (long)self.hours] Minutes:[NSString stringWithFormat:@"%li", (long)self.minutes] Seconds:[NSString stringWithFormat:@"%li", (long)self.seconds]];
     }
 }
 
@@ -274,16 +269,11 @@
     self.minutes = [currentMinute integerValue];
     self.seconds = [currentSecond integerValue];
     
-    if (animated == YES) {
-        skipOneCycle = YES;
-        [KSMHand rotateHand:self.minuteHand rotationDegree:[self degreesFromMinutes:self.minutes]];
-        [KSMHand rotateHand:self.hourHand rotationDegree:[self degreesFromHour:self.hours andMinutes:self.minutes]];
-        [KSMHand rotateHand:self.secondHand rotationDegree:[self degreesFromMinutes:self.seconds]];
-    } else {
-        self.minuteHand.transform = CGAffineTransformMakeRotation(([self degreesFromMinutes:self.minutes])*(M_PI/180));
-        self.hourHand.transform = CGAffineTransformMakeRotation(([self degreesFromHour:self.hours andMinutes:self.minutes])*(M_PI/180));
-        self.secondHand.transform = CGAffineTransformMakeRotation(([self degreesFromMinutes:self.seconds])*(M_PI/180));
-    }
+    skipOneCycle = animated;
+    [self.minuteHand setDegree:[self degreesFromMinutes:self.minutes] animated:animated];
+    [self.hourHand   setDegree:[self degreesFromHour:self.hours andMinutes:self.minutes] animated:YES];
+    [self.secondHand setDegree:[self degreesFromMinutes:self.seconds] animated:YES];
+
     if ([self.delegate respondsToSelector:@selector(currentTimeOnClock:Hours:Minutes:Seconds:)]) {
     [self.delegate currentTimeOnClock:self Hours:[NSString stringWithFormat:@"%li", (long)self.hours] Minutes:[NSString stringWithFormat:@"%li", (long)self.minutes] Seconds:[NSString stringWithFormat:@"%li", (long)self.seconds]];
     }
@@ -349,14 +339,14 @@
     if (self.seconds >= 60) {
         self.seconds = 0;
         self.minutes = self.minutes + 1;
-        [KSMHand rotateHand:self.minuteHand rotationDegree:[self degreesFromMinutes:self.minutes]];
-        [KSMHand rotateHand:self.hourHand rotationDegree:[self degreesFromHour:self.hours andMinutes:self.minutes]];
+        [self.minuteHand setDegree:[self degreesFromMinutes:self.minutes] animated:YES];
+        [self.hourHand   setDegree:[self degreesFromHour:self.hours andMinutes:self.minutes] animated:YES];
     }
     else if (self.seconds < 0) {
         self.seconds = 59;
         self.minutes = self.minutes - 1;
-        [KSMHand rotateHand:self.minuteHand rotationDegree:[self degreesFromMinutes:self.minutes]];
-        [KSMHand rotateHand:self.hourHand rotationDegree:[self degreesFromHour:self.hours andMinutes:self.minutes]];
+        [self.minuteHand setDegree:[self degreesFromMinutes:self.minutes] animated:YES];
+        [self.hourHand   setDegree:[self degreesFromHour:self.hours andMinutes:self.minutes] animated:YES];
     }
     
     if (self.minutes >= 60) {
@@ -387,7 +377,7 @@
     return degrees;
 }
 
--(float)degreesFromMinutes:(NSInteger)minutes {
+- (float)degreesFromMinutes:(NSInteger)minutes {
     float degrees = minutes*6;
     return degrees;
 }
@@ -492,4 +482,5 @@
         }
     }
 }
+
 @end

--- a/Classes/KSMHand.h
+++ b/Classes/KSMHand.h
@@ -33,22 +33,12 @@
 /// The length on the short side of the hand instance.
 @property (nonatomic) CGFloat offsetLength;
 
-// The degree the hand should be rotated by.
-@property (nonatomic) float degree;
-
 /// Is there a shadow behind the hand
 @property (nonatomic) BOOL shadowEnabled;
 
-#pragma mark Public Methods
-/**
- *  Rotates the specified hand by the specified degree angle.
- *
- *  @param hand   The KSMHand instance that you would like to rotate
- *  @param degree the degree by which you would like to rotate 
- *                <code>hand</code> by. This degree will be the degree
- *                from the Y Axis the view will be rotated by. 
- *
- */
-+ (void)rotateHand:(KSMHand *)hand rotationDegree:(float)degree;
+// The degree the hand should be rotated by.
+@property (nonatomic) float degree;
+
+- (void)setDegree:(float)degree animated:(BOOL)animated;
 
 @end

--- a/Classes/KSMHand.m
+++ b/Classes/KSMHand.m
@@ -10,9 +10,7 @@
 
 @implementation KSMHand
 
-#pragma mark UIViewDelegate
-- (id)initWithFrame:(CGRect)frame
-{
+- (id)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
     if (self) {
         self.backgroundColor = [UIColor clearColor];
@@ -20,19 +18,21 @@
     return self;
 }
 
-- (void)drawRect:(CGRect)rect
-{
+- (void)drawRect:(CGRect)rect {
+
     // the frame needs to be drawn as if it is in a cartesian plane,
     // with the center of rotation at what is thought of as (0, 0) and
     // the far end to the top of the center, this way when we rotate
     // the view, it will look correct.
-    
+
+    CGPoint const center = self.center;
+
     // point that is the top of the hand (closes to the edge of the clock)
-    CGPoint top = CGPointMake(self.frame.size.width / 2, self.frame.size.height / 2 - self.length);
+    CGPoint const top = CGPointMake(center.x, center.y - self.length);
     
     // point at the bottom of the hand, a total distance offsetLength away from
     // the center of rotation.
-    CGPoint bottom = CGPointMake(self.frame.size.width / 2, self.frame.size.height / 2 + self.offsetLength);
+    CGPoint const bottom = CGPointMake(center.x, center.y + self.offsetLength);
     
     // draw the line from the bottom to the top that has line width self.width.
     UIBezierPath *path = [UIBezierPath bezierPath];
@@ -41,24 +41,27 @@
     [path addLineToPoint:top];
     [self.color set]; // sets teh color of the hand to be the color of the path
     [path stroke];
-    
-    // roatate the view by the allotted amount
-    [KSMHand rotateHand:self rotationDegree:self.degree];
 }
 
-#pragma mark Class Methods
-+ (void)rotateHand:(UIView *)hand rotationDegree:(float)degree;
+- (void)setDegree:(float)degree {
+    [self setDegree:degree animated:NO];
+}
 
-{
-    // animate for one second (default best time to animate - for a second hand
-    // it will take exactly 1 second to move, and for the other hands it doesn't
-    // really matter how long it takes to move.
-    [UIView animateWithDuration:1.0
-                     animations:^{
-                         // set the angle of the hand to be how far offset the
-                         // second is.
-                         hand.transform = CGAffineTransformMakeRotation(degree * (M_PI / 180));
-                     }];
+- (void)setDegree:(float)degree animated:(BOOL)animated {
+    _degree = degree;
+    CGAffineTransform const transform = CGAffineTransformMakeRotation(self.degree * M_PI / 180);
+
+    if (animated) {
+        // animate for one second (default best time to animate - for a second hand
+        // it will take exactly 1 second to move, and for the other hands it doesn't
+        // really matter how long it takes to move.
+        [UIView animateWithDuration:1.0
+                         animations:^{
+                             self.transform = transform;
+                         }];
+    } else {
+        self.transform = transform;
+    }
 }
 
 @end


### PR DESCRIPTION
### The bug fixed

These changes allows the clock hands to safely redraw even with a transformation applied. The old code was breaking the clock after redraw like so:

<img src="https://cloud.githubusercontent.com/assets/922687/14499939/c22dadee-01a8-11e6-89c1-a96e672a7971.PNG" alt="Broken Clock" width="375">

The cause of this bug was in using of view's frame property in drawRect: method when transform is not the identity transformation.

### Embedded podspec

The `BEMAnalogClock.podspec.json` is included from here: https://github.com/CocoaPods/Specs/blob/master/Specs/BEMAnalogClock/1.4/BEMAnalogClock.podspec.json

Having a podspec in the repo allows to attach the repo as a pod. It's extremely useful with forks!

It would be better to have the podspec in the Ruby syntax, but don't have one and don't want to rewrite it by hands.